### PR TITLE
Automatic list of all peers

### DIFF
--- a/bin/index
+++ b/bin/index
@@ -4,6 +4,22 @@ use strict;
 use Cwd;
 use File::Basename;
 
+sub read_hash {
+  my $fn = shift;
+  my $hash = shift;
+  open(my $fh, '<', $fn) or return;
+  while (my $line=<$fh>) {
+    chomp($line);
+    my ($key, $value) = split / /, $line, 2;
+    $hash->{$key} = $value;
+  }
+  close($fh);
+}
+
+my %titles = ();
+read_hash('../titles.common', \%titles);
+read_hash('../titles', \%titles);
+
 my $RUN=cwd();
 $RUN = basename($RUN);
 
@@ -16,10 +32,32 @@ $NOTES =~ s/&/&amp;/g;
 
 my $time = scalar(gmtime());
 
+my $THISHOST = $ENV{THISHOST};
+my $FREQ = $ENV{FREQ};
+
+my @remotes = glob("remote-statistics.*.svg");
+my $ALL_REMOTES = "";
+my $ALL_REMOTES_WITH_LINK = "";
+foreach my $r (@remotes) {
+  my $remote = $r;
+  $remote =~ s/^remote-statistics\.//;
+  $remote =~ s/\.svg$//;
+  my $key = $remote;
+  $key =~ s/_/:/g;
+  my $desc = $titles{"statistics.$key"} || $key;
+  my $img = "<img src=\"$r\" alt=\"Remote clock: $desc\" />";
+  $ALL_REMOTES .= "$img<br />\n";
+  $ALL_REMOTES_WITH_LINK .= "<a href=\"$remote\">$img</a><br />\n";
+}
+
 open(TMPL,"<","index.html.tmpl");
 while(<TMPL>) {
   s/__RUN__/$RUN/g;
   s/__NOTES__/$NOTES/g;
   s/__TIME__/$time/g;
+  s/__THISHOST__/$THISHOST/g;
+  s/__FREQ__/$FREQ/g;
+  s,__ALL_REMOTES__,$ALL_REMOTES,g;
+  s,__ALL_REMOTES_WITH_LINK__,$ALL_REMOTES_WITH_LINK,g;
   print;
 }

--- a/bin/offset-graph
+++ b/bin/offset-graph
@@ -46,24 +46,28 @@ fi
 #  echo
 #) | gnuplot
 
+rm remote-statistics.*.{png,svg}
 echo "$titles" | while read file title; do
   imagename=`echo $file | sed 's/:/_/g'`
   measurements_file=`echo $file | sed 's/^statistics/measurements/'`
-  (
-    if [ -f $measurements_file ]; then
-      FIFTY=`../bin/percentile 10 50 $measurements_file | ../bin/mul 1000000`
-      CUSTOM="set label 1 gprintf('50%% = $FIFTY us',50) at graph 0.01,0.05 left front"
-      ../bin/graph-header remote-${imagename}.png "%1.0f us" "offset of $title" "$CUSTOM"
-      echo "'$measurements_file' using 1:(\$11*1000000) title 'offset' with line, \\"
-      echo "'$measurements_file' using 1:((\$11+\$12/2)*1000000) title 'offset+rtt/2' with line, \\"
-      echo "'$measurements_file' using 1:((\$11-\$12/2)*1000000) title 'offset-rtt/2' with line, \\"
-      echo "$FIFTY title '50th percentile'"
-    else
-      FIFTY=`../bin/percentile 3 50 $file | ../bin/mul 1000000`
-      CUSTOM="set label 1 gprintf('50%% = $FIFTY us',50) at graph 0.01,0.05 left front"
-      ../bin/graph-header remote-${imagename}.png "%1.0f us" "offset of $title" "$CUSTOM"
-      echo "'$file' using 1:(\$4*1000000) title 'offset' with line, \\"
-      echo "$FIFTY title '50th percentile'"
-    fi
-  ) | gnuplot
+  # Run only (1) for existing files and (2) once, so `titles.*` can be a sub-/superset
+  if [ -f "$file" -a ! -f "remote-${imagename}.png" -a ! -f "remote-${imagename}.svg" ]; then
+    (
+      if [ -f $measurements_file ]; then
+        FIFTY=`../bin/percentile 10 50 $measurements_file | ../bin/mul 1000000`
+        CUSTOM="set label 1 gprintf('50%% = $FIFTY us',50) at graph 0.01,0.05 left front"
+        ../bin/graph-header remote-${imagename}.png "%1.0f us" "offset of $title" "$CUSTOM"
+        echo "'$measurements_file' using 1:(\$11*1000000) title 'offset' with line, \\"
+        echo "'$measurements_file' using 1:((\$11+\$12/2)*1000000) title 'offset+rtt/2' with line, \\"
+        echo "'$measurements_file' using 1:((\$11-\$12/2)*1000000) title 'offset-rtt/2' with line, \\"
+        echo "$FIFTY title '50th percentile'"
+      else
+        FIFTY=`../bin/percentile 3 50 $file | ../bin/mul 1000000`
+        CUSTOM="set label 1 gprintf('50%% = $FIFTY us',50) at graph 0.01,0.05 left front"
+        ../bin/graph-header remote-${imagename}.png "%1.0f us" "offset of $title" "$CUSTOM"
+        echo "'$file' using 1:(\$4*1000000) title 'offset' with line, \\"
+        echo "$FIFTY title '50th percentile'"
+      fi
+    ) | gnuplot
+  fi
 done

--- a/bin/run
+++ b/bin/run
@@ -65,6 +65,5 @@ if [ -f log/snr-history2 ]; then
   sed 's/ \([0-9]\+:[0-9]\+\) / \1:00 /' <log/snr-history2 | ../bin/timestamps | limit_time >snr-history2
 fi
 
-../bin/index >index.html
-
 ../bin/plot
+../bin/index >index.html


### PR DESCRIPTION
Allow use of all active remote peer graphics using `__ALL_REMOTES__` and `__ALL_REMOTES_WITH_LINK__` macros in the templates.