### PR TITLE
Call /bin/bash instead of /bin/sh.

### DIFF
--- a/bin/copy-logfiles.example
+++ b/bin/copy-logfiles.example
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cd log-chrony || exit 1
 rsync -avP --delete remoteserver.example.com:/var/log/chrony/ .

--- a/bin/copy-to-website.example
+++ b/bin/copy-to-website.example
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 
 rsync --delete -avP *.png *.html ~/my.www.dir/html/graphs/

--- a/bin/diff-freq-graph
+++ b/bin/diff-freq-graph
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 (
 ../bin/graph-header all-diff-freq.png "%1.1f us/s" "all clocks (diff freq)" "set yrange [-3:3]"

--- a/bin/foreach-stat
+++ b/bin/foreach-stat
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 TEMPLATE=$1
 if [ -z "$TEMPLATE" ]; then

--- a/bin/graph-header
+++ b/bin/graph-header
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 FILENAME=$1
 FORMAT=$2

--- a/bin/local-clock-graph
+++ b/bin/local-clock-graph
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 gnuplot <<EOF
 set terminal png size 900,600

--- a/bin/loop
+++ b/bin/loop
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 while :; do
   ../bin/run

--- a/bin/offset-graph
+++ b/bin/offset-graph
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 (
 ../bin/graph-header all-offset.png "%1.0f us" "all clocks (offset)" ""

--- a/bin/plot
+++ b/bin/plot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export GDFONTPATH=/usr/share/fonts/liberation
 export GNUPLOT_DEFAULT_GDFONT=LiberationSans-Regular

--- a/bin/run
+++ b/bin/run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -x startime ]; then
   STARTIME=`./startime`

--- a/bin/skew-graph
+++ b/bin/skew-graph
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 (
 ../bin/graph-header all-skew.png "%1.0f us/s" "all clocks (skew)" "set yrange [-10:10]"


### PR DESCRIPTION
Several of the scripts require `/bin/bash`, but declare `/bin/sh`. This commit by @inkdot7 fixes it. I hope it is ok to merge, @inkdot7?