### PR TITLE
Use SVG

### DIFF
--- a/bin/copy-to-website.example
+++ b/bin/copy-to-website.example
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rsync --delete -avP *.png *.html ~/my.www.dir/html/graphs/
+rsync --delete -avP *.svg *.html ~/my.www.dir/html/graphs/

--- a/bin/diff-freq-graph
+++ b/bin/diff-freq-graph
@@ -10,7 +10,7 @@ LINSCALELIMIT=`echo $LINSCALELIMIT | ../bin/mul 1000000`
 # echo $LINSCALELIMIT
 
 (
-../bin/graph-header all-diff-freq.png $LINSCALELIMIT "%1.1f us/s" "all clocks (diff freq)" "set yrange [-3:3]"
+../bin/graph-header all-diff-freq.svg $LINSCALELIMIT "%1.1f us/s" "all clocks (diff freq)" "set yrange [-3:3]"
 ../bin/foreach-stat "'__FILE__' using 1:(\$6*1000000) title '__TITLE__' with line \\"
 echo 
 ) | gnuplot

--- a/bin/graph-header
+++ b/bin/graph-header
@@ -12,7 +12,8 @@ YTICS=`../bin/linlogytics $LINSCALELIMIT`
 #echo $YTICS 1>&2
 
 cat <<EOF
-set terminal png size 900,600
+set terminal svg size 900,600 font "monospace"
+set colorsequence classic
 set xdata time
 set timefmt "%s"
 set output "$FILENAME"

--- a/bin/local-clock-graph
+++ b/bin/local-clock-graph
@@ -7,10 +7,11 @@ LINSCALELIMIT=`../bin/linscalelimit 1 5 tracking.log | ../bin/mul 1000000`
 YTICS=`../bin/linlogytics $LINSCALELIMIT`
 
 gnuplot <<EOF
-set terminal png size 900,600
+set terminal svg size 900,600 font "monospace"
+set colorsequence classic
 set xdata time
 set timefmt "%s"
-set output "local-clock.png"
+set output "local-clock.svg"
 set grid
 set xlabel "Time"
 set format x "%d-%H:%M"
@@ -38,10 +39,11 @@ ONE=`../bin/percentile 8 1 tracking.log | ../bin/mul 1000000`
 NF_M_F=`echo $NINETYFIVE - $FIVE | bc`
 NN_M_O=`echo $NINETYNINE - $ONE | bc`
 gnuplot <<EOF
-set terminal png size 900,600
+set terminal svg size 900,600 font "monospace"
+set colorsequence classic
 set xdata time
 set timefmt "%s"
-set output "local-clock-stddev.png"
+set output "local-clock-stddev.svg"
 set grid
 set xlabel "Time"
 set format x "%d-%H:%M"
@@ -73,10 +75,11 @@ ONE=`../bin/percentile 4 1 tracking.log`
 NF_M_F=`echo $NINETYFIVE - $FIVE | bc`
 NN_M_O=`echo $NINETYNINE - $ONE | bc`
 gnuplot <<EOF
-set terminal png size 900,600
+set terminal svg size 900,600 font "monospace"
+set colorsequence classic
 set xdata time
 set timefmt "%s"
-set output "local-clock-skew.png"
+set output "local-clock-skew.svg"
 set grid
 set xlabel "Time"
 set format x "%d-%H:%M"

--- a/bin/offset-graph
+++ b/bin/offset-graph
@@ -8,7 +8,7 @@ done
 LINSCALELIMIT=`echo $LINSCALELIMIT | ../bin/mul 1000000`
 
 (
-../bin/graph-header all-offset.png $LINSCALELIMIT "%1.0f us" "all clocks (offset)" ""
+../bin/graph-header all-offset.svg $LINSCALELIMIT "%1.0f us" "all clocks (offset)" ""
 ../bin/foreach-stat "'__FILE__' using 1:(\$4*1000000) title '__TITLE__' with line \\"
 echo 
 ) | gnuplot
@@ -24,7 +24,7 @@ else
 fi
 
 #(
-#  ../bin/graph-header remote-strat1.png 1 "%1.0f us" "offset of remote strat1s" ""
+#  ../bin/graph-header remote-strat1.svg 1 "%1.0f us" "offset of remote strat1s" ""
 #  i=0
 #  echo "$titles" | while read file title; do
 #    if [ $i != 0 ]; then
@@ -37,7 +37,7 @@ fi
 #) | gnuplot
 #
 #(
-#  ../bin/graph-header remote-strat1-downstream.png 1 "%1.0f us" "offset-rtt/2 of remote strat1s" ""
+#  ../bin/graph-header remote-strat1-downstream.svg 1 "%1.0f us" "offset-rtt/2 of remote strat1s" ""
 #  i=0
 #  echo "$titles" | while read file title; do
 #    measurements_file=`echo $file | sed 's/^statistics/measurements/'`
@@ -57,13 +57,13 @@ echo "$titles" | while read file title; do
   imagename=`echo $file | sed 's/:/_/g'`
   measurements_file=`echo $file | sed 's/^statistics/measurements/'`
   # Run only (1) for existing files and (2) once, so `titles.*` can be a sub-/superset
-  if [ -f "$file" -a ! -f "remote-${imagename}.png" -a ! -f "remote-${imagename}.svg" ]; then
+  if [ -f "$file" -a ! -f "remote-${imagename}.svg" -a ! -f "remote-${imagename}.svg" ]; then
     (
       if [ -f $measurements_file ]; then
         FIFTY=`../bin/percentile 10 50 $measurements_file | ../bin/mul 1000000`
         CUSTOM="set label 1 gprintf('50%% = $FIFTY us',50) at graph 0.01,0.05 left front"
         LINSCALELIMIT=`../bin/linscalelimit 1 10 $measurements_file | ../bin/mul 1000000`
-        ../bin/graph-header remote-${imagename}.png $LINSCALELIMIT "%1.0f us" "offset of $title" "$CUSTOM"
+        ../bin/graph-header remote-${imagename}.svg $LINSCALELIMIT "%1.0f us" "offset of $title" "$CUSTOM"
         echo "'$measurements_file' using 1:(\$11*1000000) title 'offset' with line, \\"
         echo "'$measurements_file' using 1:((\$11+\$12/2)*1000000) title 'offset+rtt/2' with line, \\"
         echo "'$measurements_file' using 1:((\$11-\$12/2)*1000000) title 'offset-rtt/2' with line, \\"
@@ -72,7 +72,7 @@ echo "$titles" | while read file title; do
         FIFTY=`../bin/percentile 3 50 $file | ../bin/mul 1000000`
         CUSTOM="set label 1 gprintf('50%% = $FIFTY us',50) at graph 0.01,0.05 left front"
         LINSCALELIMIT=`../bin/linscalelimit 1 3 $file | ../bin/mul 1000000`
-        ../bin/graph-header remote-${imagename}.png $LINSCALELIMIT "%1.0f us" "offset of $title" "$CUSTOM"
+        ../bin/graph-header remote-${imagename}.svg $LINSCALELIMIT "%1.0f us" "offset of $title" "$CUSTOM"
         echo "'$file' using 1:(\$4*1000000) title 'offset' with line, \\"
         echo "$FIFTY title '50th percentile'"
       fi

--- a/bin/plot
+++ b/bin/plot
@@ -15,10 +15,11 @@ ONE=`../bin/percentile 3 1 tracking.log`
 NF_M_F=`echo $NINETYFIVE - $FIVE | bc`
 NN_M_O=`echo $NINETYNINE - $ONE | bc`
 gnuplot <<EOF
-set terminal png size 900,600
+set terminal svg size 900,600 font "monospace"
+set colorsequence classic
 set xdata time
 set timefmt "%s"
-set output "percentiles.png"
+set output "percentiles.svg"
 set grid
 set xlabel "Time"
 set format x "%d-%H:%M"
@@ -51,10 +52,11 @@ NN_M_O=`echo $NINETYNINE - $ONE | bc`
 LINSCALELIMIT=`../bin/linscalelimit 1 5 tracking.log | ../bin/mul 1000000`
 YTICS=`../bin/linlogytics $LINSCALELIMIT`
 gnuplot <<EOF
-set terminal png size 900,600
+set terminal svg size 900,600 font "monospace"
+set colorsequence classic
 set xdata time
 set timefmt "%s"
-set output "percentiles-offset.png"
+set output "percentiles-offset.svg"
 set grid
 set xlabel "Time"
 set format x "%d-%H:%M"
@@ -90,8 +92,9 @@ SEVENTYFIVE=`../bin/percentile 5 75 tracking.log | ../bin/mul 1000000`
 TWENTYFIVE=`../bin/percentile 5 25 tracking.log | ../bin/mul 1000000`
 
 gnuplot <<EOF
-set terminal png size 900,600
-set output "offset-histogram.png"
+set terminal svg size 900,600 font "monospace"
+set colorsequence classic
+set output "offset-histogram.svg"
 set grid
 set xtic rotate by -45 scale 0
 set title "Local Clock Offsets - Histogram"
@@ -118,10 +121,11 @@ EOF
 
 # optional GPS tracking
 #gnuplot <<EOF
-#set terminal png size 900,600
+#set terminal svg size 900,600 font "monospace"
+set colorsequence classic
 #set xdata time
 #set timefmt "%s"
-#set output "gps-lock.png"
+#set output "gps-lock.svg"
 #set grid
 #set xlabel "Time"
 #set format x "%d-%H:%M"
@@ -135,8 +139,9 @@ EOF
 #
 #../bin/histogram-snr <snr-history >snr-history.history
 #gnuplot <<EOF
-#set terminal png size 900,600
-#set output "gps-snr-histogram.png"
+#set terminal svg size 900,600 font "monospace"
+set colorsequence classic
+#set output "gps-snr-histogram.svg"
 #set grid
 #set xtic rotate by -45 scale 0
 #set title "GPS SNR histogram"
@@ -148,10 +153,11 @@ EOF
 #
 #../bin/snr-hourly snr-history >snr-history.hourly
 #gnuplot <<EOF
-#set terminal png size 900,600
+#set terminal svg size 900,600 font "monospace"
+set colorsequence classic
 #set xdata time
 #set timefmt "%s"
-#set output "gps-snr-hourly.png"
+#set output "gps-snr-hourly.svg"
 #set grid
 #set xlabel "Time"
 #set format x "%d-%H:%M"

--- a/bin/skew-graph
+++ b/bin/skew-graph
@@ -8,7 +8,7 @@ done
 LINSCALELIMIT=`echo $LINSCALELIMIT | ../bin/mul 1000000`
 
 (
-../bin/graph-header all-skew.png $LINSCALELIMIT "%1.1f us/s" "all clocks (skew)" "set yrange [-10:10]"
+../bin/graph-header all-skew.svg $LINSCALELIMIT "%1.1f us/s" "all clocks (skew)" "set yrange [-10:10]"
 ../bin/foreach-stat "'__FILE__' using 1:(\$6*1000000) title '__TITLE__' with line \\"
 echo 
 ) | gnuplot

--- a/runX/index.html.tmpl
+++ b/runX/index.html.tmpl
@@ -8,15 +8,15 @@
 <p>
 Last update - __TIME__ GMT
 </p>
-<img src="local-clock.png" alt="Local Clock: Frequency + Offset"><br>
-<img src="percentiles.png" alt="Local Clock: Frequency detail"><br>
-<img src="percentiles-offset.png" alt="Local Clock: Offset detail"><br>
-<img src="offset-histogram.png" alt="Local Clock: Offset histogram"><br>
-<img src="local-clock-skew.png" alt="Local Clock: Skew"><br>
-<img src="local-clock-stddev.png" alt="Local Clock: stddev"><br>
-<img src="all-diff-freq.png" alt="Remote Clocks: Frequency Difference"><br>
-<img src="all-offset.png" alt="Remote Clocks: Offsets"><br>
-<img src="all-skew.png" alt="Remote Clocks: Skew"><br>
+<img src="local-clock.svg" alt="Local Clock: Frequency + Offset"><br>
+<img src="percentiles.svg" alt="Local Clock: Frequency detail"><br>
+<img src="percentiles-offset.svg" alt="Local Clock: Offset detail"><br>
+<img src="offset-histogram.svg" alt="Local Clock: Offset histogram"><br>
+<img src="local-clock-skew.svg" alt="Local Clock: Skew"><br>
+<img src="local-clock-stddev.svg" alt="Local Clock: stddev"><br>
+<img src="all-diff-freq.svg" alt="Remote Clocks: Frequency Difference"><br>
+<img src="all-offset.svg" alt="Remote Clocks: Offsets"><br>
+<img src="all-skew.svg" alt="Remote Clocks: Skew"><br>
 __ALL_REMOTES__
 <pre>
 __RUN__ notes:


### PR DESCRIPTION
This commit does three things:
* Use SVG, which renders more cleanly than PNG and does not really require any fonts any more.
* Use monospace, a matter of personal taste that we can discuss later.
* Use classic colorsequence, which copes with &gt; 8 sources much better.

Deployed at: https://esietb.com/ntp/index.html