### PR TITLE
Use hostname if THISHOST is not set

### DIFF
--- a/bin/index
+++ b/bin/index
@@ -3,6 +3,7 @@
 use strict;
 use Cwd;
 use File::Basename;
+use Sys::Hostname;
 
 sub read_hash {
   my $fn = shift;
@@ -32,7 +33,7 @@ $NOTES =~ s/&/&amp;/g;
 
 my $time = scalar(gmtime());
 
-my $THISHOST = $ENV{THISHOST};
+my $THISHOST = $ENV{THISHOST} // hostname();
 my $FREQ = $ENV{FREQ};
 
 my @remotes = glob("remote-statistics.*.{svg,png}");


### PR DESCRIPTION
THISHOST is never explained in the README, so maybe we should just let it work *somewhat* when it's not set.